### PR TITLE
Remove `none` from the update options

### DIFF
--- a/HDP.md
+++ b/HDP.md
@@ -194,14 +194,18 @@ GameInfoResponse   | The exact same format as the ``Game Info Response``
 
 Notifies the server that the player moved its serpent and informs the last update that was received.
 
-    ClientUpdate => LastServerTick Action
+    ClientUpdate => LastServerTick Direction
     LastServerTick => ushort
-    Action => uchar
+    Direction => LEFT | RIGHT | UP | DOWN
+    LEFT => 1
+    RIGHT => 2
+    UP => 4
+    DOWN => 8
 
 Field            | Description
 -----------------|-------------
 LastServerTick   | Should be the last tick received from the server
-Action           | A direction change, set the char to 1 for left, 2 for right, 4 for up and 8 for down, any other value is ignored
+Direction        | The desired serpent direction
 
 ### Server Update ###
 

--- a/elvis.config
+++ b/elvis.config
@@ -3,7 +3,7 @@
    elvis,
    [
     {config,
-     [#{dirs => ["src", "src/**", "test"],
+     [#{dirs => ["src", "src/**"],
         filter => "*.erl",
         rules => [{elvis_style, line_length, #{limit => 80,
                                                skip_comments => false}},
@@ -29,6 +29,34 @@
                   {elvis_style, state_record_and_type},
                   {elvis_style, no_spec_with_records},
                   {elvis_style, dont_repeat_yourself, #{min_complexity => 10}}
+                 ]
+       },
+      #{dirs => ["test"],
+        filter => "*.erl",
+        rules => [{elvis_style, line_length, #{limit => 80,
+                                               skip_comments => false}},
+                  {elvis_style, no_tabs},
+                  {elvis_style, no_trailing_whitespace},
+                  {elvis_style, macro_names},
+                  {elvis_style, macro_module_names},
+                  {elvis_style, operator_spaces, #{rules => [{right, ","},
+                                                             {right, "++"},
+                                                             {left, "++"}]}},
+                  {elvis_style, nesting_level, #{level => 3}},
+                  {elvis_style, god_modules, #{limit => 35}},
+                  {elvis_style, no_if_expression},
+                  {elvis_style, invalid_dynamic_call, #{ignore => [spts_test_utils]}},
+                  {elvis_style, used_ignored_variable},
+                  {elvis_style, no_behavior_info},
+                  {
+                    elvis_style,
+                    module_naming_convention,
+                    #{regex => "^s([a-z][a-z0-9]*_?)*(_SUITE)?$",
+                      ignore => []}
+                  },
+                  {elvis_style, state_record_and_type},
+                  {elvis_style, no_spec_with_records},
+                  {elvis_style, dont_repeat_yourself, #{min_complexity => 25}}
                  ]
        },
       #{dirs => ["."],

--- a/src/clients/ai/spts_cli.erl
+++ b/src/clients/ai/spts_cli.erl
@@ -26,7 +26,7 @@
 -callback init(pos_integer(), spts_hdp:game(), term()) -> term().
 -callback handle_update(
   [spts_hdp:diff()], pos_integer(), spts_hdp:game(), term()) ->
-  {none | spts_games:direction(), term()}.
+  {spts_games:direction(), term()}.
 -callback terminate(term(), pos_integer(), spts_hdp:game(), term()) -> _.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/src/clients/ai/spts_cli_random.erl
+++ b/src/clients/ai/spts_cli_random.erl
@@ -31,14 +31,8 @@ init(_SerpentId, _Game, noargs) -> #state{}.
 
 -spec handle_update(
   [spts_hdp:diff()], pos_integer(), spts_hdp:game(), state()) ->
-  {none | spts_games:direction(), state()}.
-handle_update([], _SerpentId, _Game, State) ->
-  %NOTE: no changes, nothing to do
-  {none, State};
-handle_update(Diffs, SerpentId, Game, State) ->
-  lager:notice(
-    "\n\tDiffs = ~p,\n\tSerpentId = ~p,\n\tGame = ~p",
-    [Diffs, SerpentId, Game]),
+  {spts_games:direction(), state()}.
+handle_update(_Diffs, _SerpentId, _Game, State) ->
   Direction = ktn_random:pick([up, down, left, right]),
   {Direction, State}.
 

--- a/src/models/spts_games.erl
+++ b/src/models/spts_games.erl
@@ -245,6 +245,16 @@ diffs(OldGame, NewGame, fruit) ->
     OldFruit -> [];
     NewFruit -> [#{type => fruit, data => NewFruit}]
   end;
+diffs(OldGame, NewGame, serpents) ->
+  Sort =
+    fun(SerpentA, SerpentB) ->
+      spts_serpents:name(SerpentA) =< spts_serpents:name(SerpentB)
+    end,
+  OldSerpents = lists:sort(Sort, serpents(OldGame)),
+  case lists:sort(Sort, serpents(NewGame)) of
+    OldSerpents -> [];
+    NewSerpents -> [#{type => serpents, data => NewSerpents}]
+  end;
 diffs(OldGame, NewGame, Type) ->
   OldData = maps:get(Type, OldGame),
   case maps:get(Type, NewGame) of

--- a/src/protocol/spts_hdp_game_handler.erl
+++ b/src/protocol/spts_hdp_game_handler.erl
@@ -245,6 +245,5 @@ purge_history(MinTick, History = [{MinTick, _Game} | _Rest], Acc) ->
 purge_history(MinTick, [Newer | History], Acc) ->
   purge_history(MinTick, History, [Newer | Acc]).
 
-maybe_change_direction(_GameId, _SerpentName, undefined) -> ok;
 maybe_change_direction(GameId, SerpentName, Direction) ->
   ok = spts_core:turn(GameId, SerpentName, Direction).

--- a/src/protocol/spts_hdp_handler.erl
+++ b/src/protocol/spts_hdp_handler.erl
@@ -182,11 +182,15 @@ handle_message(join,
                 Metadata)
   end;
 handle_message(
-  action, <<LastServerTick:?USHORT, Action:?UCHAR>>, Metadata) ->
+  action, <<LastServerTick:?USHORT, DirData:?UCHAR>>, Metadata) ->
   Address = {Metadata#metadata.ip, Metadata#metadata.port},
-  Direction = get_direction(Action),
-  spts_hdp_game_handler:user_update(
-    Metadata#metadata.user_id, Address, LastServerTick, Direction);
+  case get_direction(DirData) of
+    undefined ->
+      lager:warning("Unknown direction: ~p", [DirData]);
+    Direction ->
+      spts_hdp_game_handler:user_update(
+        Metadata#metadata.user_id, Address, LastServerTick, Direction)
+  end;
 handle_message(MessageType, Garbage, Metadata) ->
   lager:warning(
     "Malformed Message:~n~p~n~p~n~p", [MessageType, Garbage, Metadata]).

--- a/src/utils/spts_hdp.erl
+++ b/src/utils/spts_hdp.erl
@@ -119,8 +119,8 @@ ping(MsgId) -> head(ping, MsgId).
   binary().
 update(MsgId, UserId, LastTick, Direction) ->
   H = head(client_update, MsgId, UserId),
-  Action = action(Direction),
-  <<H/binary, LastTick:?USHORT, Action:?UCHAR>>.
+  DirData = direction(Direction),
+  <<H/binary, LastTick:?USHORT, DirData:?UCHAR>>.
 
 -spec head(byte() | type(), pos_integer()) -> binary().
 head(Flags, MsgId) ->
@@ -268,11 +268,10 @@ parse_serpents(Serpents) ->
   || <<Id:?UINT, NameSize:?UCHAR, Name:NameSize/binary>> <= Serpents
   ].
 
-action(left)  -> 1;
-action(right) -> 2;
-action(up)    -> 4;
-action(down)  -> 8;
-action(none)  -> 0.
+direction(left)  -> 1;
+direction(right) -> 2;
+direction(up)    -> 4;
+direction(down)  -> 8.
 
 do_recv(UdpSocket) ->
   {ok, {{127, 0, 0, 1}, _, Packet}} = gen_udp:recv(UdpSocket, ?VERY_MUCH, 1000),

--- a/src/utils/spts_hdp.erl
+++ b/src/utils/spts_hdp.erl
@@ -64,7 +64,7 @@
 
 -export_type([parser/0, type/0, game/0, diff/0, message/0]).
 -export([recv/1, recv/2, parse/1, parse/2, send/2]).
--export([join/3, ping/1, games/1, game/2, head/2, update/4]).
+-export([join/3, ping/1, games/1, game/2, head/2, head/3, update/4]).
 
 -spec send(port(), iodata()) -> ok.
 send(UdpSocket, Message) ->
@@ -125,6 +125,8 @@ update(MsgId, UserId, LastTick, Direction) ->
 -spec head(byte() | type(), pos_integer()) -> binary().
 head(Flags, MsgId) ->
   head(Flags, MsgId, 0).
+
+-spec head(byte() | type(), pos_integer(), pos_integer()) -> binary().
 head(Flags, MsgId, UserId) ->
   {_, _, Nanos} = os:timestamp(),
   head(Flags, MsgId, Nanos rem 65536, UserId).

--- a/src/utils/spts_hdp.erl
+++ b/src/utils/spts_hdp.erl
@@ -126,7 +126,7 @@ update(MsgId, UserId, LastTick, Direction) ->
 head(Flags, MsgId) ->
   head(Flags, MsgId, 0).
 
--spec head(byte() | type(), pos_integer(), pos_integer()) -> binary().
+-spec head(byte() | type(), pos_integer(), non_neg_integer()) -> binary().
 head(Flags, MsgId, UserId) ->
   {_, _, Nanos} = os:timestamp(),
   head(Flags, MsgId, Nanos rem 65536, UserId).

--- a/test/spts_hdp_SUITE.erl
+++ b/test/spts_hdp_SUITE.erl
@@ -314,7 +314,7 @@ state_server_update(Config) ->
   GameName = spts_games:id(Game),
   Process = spts_hdp_game_handler:process_name(GameId),
 
-  {S1Id, GD1} = do_join(GameId, <<"s1">>, Config),
+  {S1Id, Dir1, GD1} = do_join(GameId, <<"s1">>, Config),
   #{tickrate := 1} = GD1,
 
   ct:comment("The game starts"),
@@ -327,7 +327,7 @@ state_server_update(Config) ->
   [countdown] = [Data || #{data := Data, type := state} <- Diffs],
 
   ct:comment("The client acks the update"),
-  ok = hdp_direct_send(spts_hdp:update(3, S1Id, Tick, none), Config),
+  ok = hdp_direct_send(spts_hdp:update(3, S1Id, Tick, Dir1), Config),
 
   ct:comment("After a tick, the server sends an update with no diffs"),
   Process ! tick,
@@ -343,7 +343,7 @@ countdown_server_update(Config) ->
   GameName = spts_games:id(Game),
   Process = spts_hdp_game_handler:process_name(GameId),
 
-  {S1Id, GD1} = do_join(GameId, <<"s1">>, Config),
+  {S1Id, Dir1, GD1} = do_join(GameId, <<"s1">>, Config),
   #{tickrate := 1} = GD1,
 
   ct:comment("The game starts"),
@@ -364,7 +364,7 @@ countdown_server_update(Config) ->
   {Tick, [_|_]} = diffs(hdp_recv(Config)),
 
   ct:comment("The client acks the updates"),
-  ok = hdp_direct_send(spts_hdp:update(3, S1Id, Tick, none), Config),
+  ok = hdp_direct_send(spts_hdp:update(3, S1Id, Tick, Dir1), Config),
 
   ct:comment("After a tick, the server sends an update with no diffs"),
   Process ! tick,
@@ -382,7 +382,7 @@ rounds_server_update(Config) ->
   GameName = spts_games:id(Game),
   Process = spts_hdp_game_handler:process_name(GameId),
 
-  {S1Id, GD1} = do_join(GameId, <<"s1">>, Config),
+  {S1Id, Dir1, GD1} = do_join(GameId, <<"s1">>, Config),
   #{tickrate := 1} = GD1,
 
   ct:comment("The game starts"),
@@ -411,14 +411,14 @@ rounds_server_update(Config) ->
   clean_queue(Config),
 
   ct:comment("The client acks the updates"),
-  ok = hdp_direct_send(spts_hdp:update(3, S1Id, Tick, none), Config),
+  ok = hdp_direct_send(spts_hdp:update(3, S1Id, Tick, Dir1), Config),
 
   ct:comment("After a tick, the server sends an update with no diffs"),
   Process ! tick,
   {Tick2, []} = diffs(hdp_recv(Config)),
 
   ct:comment("The client acks the updates again"),
-  ok = hdp_direct_send(spts_hdp:update(3, S1Id, Tick2, none), Config),
+  ok = hdp_direct_send(spts_hdp:update(3, S1Id, Tick2, Dir1), Config),
 
   ct:comment("After a tick, the server sends an update with no diffs (Again)"),
   Process ! tick,
@@ -437,7 +437,7 @@ serpents_server_update(Config) ->
   {socket2, UdpSocket} = lists:keyfind(socket2, 1, Config),
   Config2 = [{socket, UdpSocket} | Config],
 
-  {S1Id, GD1} = do_join(GameId, <<"s1">>, Config),
+  {S1Id, Dir1, GD1} = do_join(GameId, <<"s1">>, Config),
   #{tickrate := 1} = GD1,
 
   ct:comment(
@@ -451,7 +451,7 @@ serpents_server_update(Config) ->
            , SId == S1Id
            ],
 
-  {S2Id, _GD2} = do_join(GameId, <<"s2">>, Config2),
+  {S2Id, _Dir2, _GD2} = do_join(GameId, <<"s2">>, Config2),
 
   ct:comment(
     "After a tick, the server sends updates with both serpents to both users"),
@@ -470,7 +470,7 @@ serpents_server_update(Config) ->
   [{_Row, _Col}] = serpent_body(S2Id, SerpentsDiff),
 
   ct:comment("The client 1 acks the update"),
-  ok = hdp_direct_send(spts_hdp:update(3, S1Id, Tick2, none), Config),
+  ok = hdp_direct_send(spts_hdp:update(3, S1Id, Tick2, Dir1), Config),
 
   ct:pal("After a tick, the server sends an update with no diffs to user 1"),
   Process ! tick,
@@ -491,7 +491,7 @@ fruit_server_update(Config) ->
   GameName = spts_games:id(Game),
   Process = spts_hdp_game_handler:process_name(GameId),
 
-  {S1Id, GD1} = do_join(GameId, <<"s1">>, Config),
+  {S1Id, Dir1, GD1} = do_join(GameId, <<"s1">>, Config),
   #{tickrate := 1} = GD1,
 
   ct:comment("The game starts"),
@@ -511,7 +511,7 @@ fruit_server_update(Config) ->
   end,
 
   ct:comment("The client acks the update"),
-  ok = hdp_direct_send(spts_hdp:update(3, S1Id, Tick, none), Config),
+  ok = hdp_direct_send(spts_hdp:update(3, S1Id, Tick, Dir1), Config),
 
   ct:comment("After a tick, the server sends an update with no diffs"),
   Process ! tick,
@@ -540,10 +540,10 @@ wrong_input(Config) ->
   GameId = spts_games:numeric_id(Game),
   GameName = spts_games:id(Game),
 
-  {SId, _} = do_join(GameId, <<"s1">>, Config),
+  {SId, Dir, _} = do_join(GameId, <<"s1">>, Config),
 
   ct:comment("Bad SerpentId is ignored"),
-  ok = hdp_direct_send(spts_hdp:update(3, SId + 1, 1, none), Config),
+  ok = hdp_direct_send(spts_hdp:update(3, SId + 1, 1, Dir), Config),
 
   ct:comment("The game is stopped"),
   ok = spts_core:stop_game(GameName),
@@ -579,7 +579,7 @@ user_update_changes_direction(Config) ->
   GameId = spts_games:numeric_id(Game),
   GameName = spts_games:id(Game),
 
-  {SId, _} = do_join(GameId, <<"s1">>, Config),
+  {SId, _, _} = do_join(GameId, <<"s1">>, Config),
   CheckDir =
     fun() ->
       spts_serpents:direction(
@@ -594,19 +594,15 @@ user_update_changes_direction(Config) ->
 
   ct:comment("Player moves right"),
   right = Turn(right, right),
-  right = Turn(none, right),
 
   ct:comment("Player moves left"),
   left = Turn(left, left),
-  left = Turn(none, left),
 
   ct:comment("Player moves up"),
   up = Turn(up, up),
-  up = Turn(none, up),
 
   ct:comment("Player moves down"),
   down = Turn(down, down),
-  down = Turn(none, down),
 
   {comment, ""}.
 
@@ -650,5 +646,8 @@ do_join(GameId, Name, Config) ->
   ct:comment("~p joins ~p", [Name, GameId]),
   ok = hdp_send(spts_hdp:join(16, GameId, Name), Config),
   ct:comment("The response is received"),
-  {join_response, 16, _, Response} = hdp_recv(Config),
-  Response.
+  {join_response, 16, _, {SId, GD}} = hdp_recv(Config),
+  Dir =
+    spts_serpents:direction(
+      spts_games:serpent(spts_core:fetch_game(GameId), Name)),
+  {SId, Dir, GD}.

--- a/test/spts_hdp_SUITE.erl
+++ b/test/spts_hdp_SUITE.erl
@@ -472,11 +472,11 @@ serpents_server_update(Config) ->
   ct:comment("The client 1 acks the update"),
   ok = hdp_direct_send(spts_hdp:update(3, S1Id, Tick2, Dir1), Config),
 
-  ct:pal("After a tick, the server sends an update with no diffs to user 1"),
+  ct:comment("After a tick, server sends an update with no diffs to user 1"),
   Process ! tick,
   no_diffs(hdp_recv(Config)),
 
-  ct:pal("After a tick, the server sends an update with diffs to user 2"),
+  ct:comment("After a tick, the server sends an update with diffs to user 2"),
   {_, Diffs2} = diffs(hdp_recv(Config2)),
 
   {comment , ""}.

--- a/test/spts_live_SUITE.erl
+++ b/test/spts_live_SUITE.erl
@@ -256,8 +256,6 @@ collision_with_serpent_self(Config) ->
     spts_games_repo:advance(
       spts_games_repo:turn(NewGame, <<"cwss1">>, left)),
 
-  ct:pal("Old: ~p~nNew: ~p~n", [NewGame, NewerGame]),
-
   ct:comment("The serpent is dead"),
   dead = spts_serpents:status(spts_games:serpent(NewerGame, <<"cwss1">>)),
 


### PR DESCRIPTION
Since, after #73, we're going to ignore out-of-order client updates and `none` assumes knowledge of *previous* updates, we should remove it and force the client to send that piece of information all the time.